### PR TITLE
Add ability to hide buttons groups separately

### DIFF
--- a/cropimg.jquery.js
+++ b/cropimg.jquery.js
@@ -108,6 +108,27 @@
        * @var boolean
        */
       showBtnTips: true,
+
+      /**
+       * Display zooming buttons?
+       * 
+       * @var boolean
+       */
+      displayZoomingButtons: true,
+
+      /**
+       * Display fixing positions buttons?
+       * 
+       * @var boolean
+       */
+      displayFixingPositionsButtons: true,
+
+      /**
+       * Display fixing size buttons?
+       * 
+       * @var boolean
+       */
+      displayFixingSizeButtons: true,
       
       /**
        * Czas animacji pokazywania i ukrywania tooltipów.
@@ -303,11 +324,17 @@
       this.draw = function() {
         this.drawContainers();
         
-        this.drawZoomingButtons();
+        if (this.main.options.displayZoomingButtons) {
+          this.drawZoomingButtons();  
+        }
         
-        this.drawFixingPositionButtons();
-        
-        this.drawFixingSizeButtons();
+        if (this.main.options.displayFixingPositionsButtons) {
+          this.drawFixingPositionButtons();  
+        }
+
+        if (this.main.options.displayFixingSizeButtons) {
+          this.drawFixingSizeButtons();  
+        }
 
         var self = this;
         


### PR DESCRIPTION
I added three new options that allow us hide the buttons separately. This submission don't change default behavior, where all buttons are displayed.

We can use as follow:

``` javascript
$(document).ready(function() {
      $('img.cropimg').cropimg({
        resultWidth:600,
        resultHeight:300,
        displayZoomingButtons: false,
        displayFixingPositionsButtons: false,
        displayFixingSizeButtons: false,
        onChange: function() {
          $('#preview-info').hide();
          $('#preview-container').show();
        }
      });
});
```
