### PR TITLE
Don't fire onInit unless all data has been properly initalized

### DIFF
--- a/cropimg.jquery.js
+++ b/cropimg.jquery.js
@@ -900,6 +900,7 @@
               };
               
               $('.ci-image-loader', self.main.imageContainer).remove();
+              self.main.data.options.onInit();
             };
             loader.src = this.main.image.attr('src');
         
@@ -1253,8 +1254,6 @@
       $(this).data('cropimg', Main.Reset);
       
       $(window).trigger('resize');
-      
-      options.onInit();
     });
   }
 })(jQuery);


### PR DESCRIPTION
Originally onInit fire once plugin's initialization code has been executed but before image data is loaded.
Putting your code in `onInit` had exact same effect as putting your code right after calling `$(..).cropimg({})`.

Now `onInit` is called after the plugin has been initialized and image is loaded and its dimensions has been defined.
